### PR TITLE
fix: add 'use strict'

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const Writable = require('stream').Writable;
 
 class AssertStream extends Writable {


### PR DESCRIPTION
I added 'use strict' directive to make this lib usable on node v4 environment.

cf. https://github.com/recruit-tech/agreed-core/pull/8
